### PR TITLE
feat(tcp): accept TCP connections and handle each on a virtual thread

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,8 @@ build/
 
 ### VS Code ###
 .vscode/
+
+
+### Log files ###
+*.log
+*.gz

--- a/pom.xml
+++ b/pom.xml
@@ -1,54 +1,91 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.5</version>
-		<relativePath/> <!-- lookup parent from repository -->
-	</parent>
-	<groupId>com.spring</groupId>
-	<artifactId>memodb</artifactId>
-	<version>0.0.1-SNAPSHOT</version>
-	<name>memodb</name>
-	<description>MemoDB is a toy key-value database. It&apos;s essentially an implementation of the popular in-memory data store, Redis</description>
-	<url/>
-	<licenses>
-		<license/>
-	</licenses>
-	<developers>
-		<developer/>
-	</developers>
-	<scm>
-		<connection/>
-		<developerConnection/>
-		<tag/>
-		<url/>
-	</scm>
-	<properties>
-		<java.version>21</java.version>
-	</properties>
-	<dependencies>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter</artifactId>
-		</dependency>
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.5.5</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+    <groupId>com.spring</groupId>
+    <artifactId>memodb</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>memodb</name>
+    <description>MemoDB is a toy key-value database. It&apos;s essentially an implementation of the popular in-memory data store, Redis</description>
+    <url/>
+    <licenses>
+        <license/>
+    </licenses>
+    <developers>
+        <developer/>
+    </developers>
+    <scm>
+        <connection/>
+        <developerConnection/>
+        <tag/>
+        <url/>
+    </scm>
+    <properties>
+        <java.version>21</java.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
 
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <version>2.1.1</version>
+        </dependency>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-maven-plugin</artifactId>
-			</plugin>
-		</plugins>
-	</build>
+
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+    
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/src/main/java/com/spring/memodb/MemodbApplication.java
+++ b/src/main/java/com/spring/memodb/MemodbApplication.java
@@ -6,8 +6,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication
 public class MemodbApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(MemodbApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(MemodbApplication.class, args);
+    }
 
 }

--- a/src/main/java/com/spring/memodb/tcp/TcpServer.java
+++ b/src/main/java/com/spring/memodb/tcp/TcpServer.java
@@ -1,0 +1,86 @@
+package com.spring.memodb.tcp;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+import com.spring.memodb.utils.ApplicationConstants;
+
+import jakarta.annotation.PreDestroy;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Simple TCP server that listens for incoming connections and delegates each
+ * connection to a TcpWorker. The server runs on a specified port and uses a
+ * virtual thread pool to handle multiple clients concurrently.
+ */
+@Component
+@Slf4j
+public class TcpServer implements CommandLineRunner {
+
+    // TCP server port provided via application properties (or defaults to 6379)
+    @Value("${tcp.server.port:6379}")
+    private int port;
+
+    private String appName = ApplicationConstants.APP_NAME;
+
+    // The server socket that listens for incoming connections
+    private static ServerSocket serverSocket;
+
+    // Executor service with virtual threads
+    ExecutorService executorService = Executors.newVirtualThreadPerTaskExecutor();
+
+    /**
+     * Starts the TCP server and listens for incoming connections. Each
+     * connection is handled by a TcpWorker running in a separate virtual thread
+     * from the thread pool.
+     */
+    @Override
+    public void run(String[] args) {
+        try {
+            serverSocket = new ServerSocket();
+            serverSocket.setReuseAddress(true); // allow quick restart of server on same port
+            serverSocket.bind(new InetSocketAddress(port));
+
+            log.info("{} server started on port {}", appName, port);
+
+            while (true) {
+                try {
+                    Socket clientSocket = serverSocket.accept(); // accept new client connection
+                    executorService.submit(new TcpWorker(clientSocket)); // handle connection in separate virtual thread
+                } catch (IOException e) {
+                    if (serverSocket.isClosed()) {
+                        log.debug("Server socket closed, stopping accept loop.");
+                        break; // exit loop on shutdown
+                    }
+                    log.error("Error accepting client connection", e);
+                }
+            }
+        } catch (IOException e) {
+            log.error("Error starting TCP server", e);
+        }
+    }
+
+    /**
+     * Shuts down the server socket and executor service when the application is
+     * stopping.
+     */
+    @PreDestroy
+    private void destroy() {
+        log.debug("Shutting down TCP server...");
+        try {
+            if (serverSocket != null && !serverSocket.isClosed()) {
+                serverSocket.close(); // unblocks accept()
+            }
+        } catch (IOException ignore) {
+        }
+        executorService.shutdown();
+    }
+}

--- a/src/main/java/com/spring/memodb/tcp/TcpWorker.java
+++ b/src/main/java/com/spring/memodb/tcp/TcpWorker.java
@@ -1,0 +1,89 @@
+package com.spring.memodb.tcp;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.Socket;
+import java.net.SocketTimeoutException;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Worker class that handles communication with a connected TCP client. Each
+ * instance runs in its own virtual thread and processes messages from the
+ * client until the connection is closed.
+ */
+@Slf4j
+public class TcpWorker implements Runnable {
+
+    // The client socket associated with this worker.
+    private final Socket clientSocket;
+
+    private static final int CONNECTION_TIMEOUT_MS = 60 * 1000; // Connection idle timeout in milliseconds, currently 60 seconds
+
+    public TcpWorker(Socket clientSocket) {
+        log.info("Accepted connection from {}", clientSocket.getRemoteSocketAddress());
+
+        this.clientSocket = clientSocket;
+
+        try {
+            clientSocket.setSoTimeout(CONNECTION_TIMEOUT_MS); // set read timeout
+        } catch (IOException e) {
+            log.error("Error setting socket timeout", e);
+        }
+    }
+
+    /*
+     * Handles communication with the connected client. Reads messages from the
+     * client and prints them to the console. Closes the connection when the
+     * client disconnects or an error occurs.
+     * 
+     * TODO: Implement actual message processing logic as needed.
+     */
+    @Override
+    public void run() {
+        // Buffered reader to read text from the client socket
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(clientSocket.getInputStream(), "UTF-8"))) {
+
+            // Read messages from the client until the connection is closed
+            while (true) {
+                try {
+                    /**
+                     * Read a line from the client. Blocking call, so this
+                     * thread will wait here until a message is received or the
+                     * client disconnects.
+                     *
+                     * TODO: Connection will still close if client keeps sending
+                     * messages without a newline character. Need to handle that
+                     * case as well. Read each byte and keep track of idle time?
+                     */
+                    String message = reader.readLine();
+
+                    // If message is null, the client has disconnected
+                    if (message == null) {
+                        log.info("Client disconnected: {}", clientSocket.getRemoteSocketAddress());
+                        break;
+                    }
+
+                    /**
+                     * Print the received message to the console. TODO: Replace
+                     * this logic as needed.
+                     */
+                    log.info("Received message from {}: {}", clientSocket.getRemoteSocketAddress(), message);
+                } catch (SocketTimeoutException e) {
+                    log.info("No data for {} milliseconds, closing connection to {}", CONNECTION_TIMEOUT_MS, clientSocket.getRemoteSocketAddress());
+                    break;
+                }
+            }
+
+        } catch (IOException e) {
+            log.error("Error handling client connection", e);
+        } finally {
+            // Ensure the socket is closed when done
+            try {
+                clientSocket.close();
+            } catch (IOException ignore) {
+            }
+        }
+    }
+}

--- a/src/main/java/com/spring/memodb/utils/ApplicationConstants.java
+++ b/src/main/java/com/spring/memodb/utils/ApplicationConstants.java
@@ -1,0 +1,12 @@
+package com.spring.memodb.utils;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties
+public final class ApplicationConstants {
+
+    public static final String APP_NAME = "MemoDB";
+
+    private ApplicationConstants() {
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,8 @@
 spring.application.name=memodb
+
+# Logging configuration
+logging.level.root=INFO
+logging.file.name=memodb.log
+
+# Server port for the TCP server
+tcp.server.port=6379


### PR DESCRIPTION
This PR adds the functionality to accept incoming TCP connections from clients and handle each in a separate set of virtual thread pool.

Additions / Changes:

- TcpServer class - Starts a TCP server on a specific port and accepts connections from clients offloading them to the TcpWorker in a new virtual thread.
- TcpWorker class - Reads incoming data from clients and logs them for now. In future, instead of logging we need to handle the messages properly.
- Added Slf4j logging.

Screenshots:
<img width="1331" height="52" alt="Screenshot 2025-08-28 at 2 28 04 AM" src="https://github.com/user-attachments/assets/e4b3a2e4-2397-4afb-af09-7ba95eb40541" />

<img width="1341" height="117" alt="Screenshot 2025-08-28 at 2 27 09 AM" src="https://github.com/user-attachments/assets/4ee9edd2-0c5a-45be-a583-71f5ad7c1901" />
