### PR TITLE
In-memory store with ConcurrentHashMap

### DIFF
--- a/src/main/java/com/spring/memodb/store/Entry.java
+++ b/src/main/java/com/spring/memodb/store/Entry.java
@@ -1,0 +1,47 @@
+package com.spring.memodb.store;
+
+import com.spring.memodb.resp.RespType;
+
+/**
+ * Represents an entry in the in-memory key-value store, encapsulating the
+ * stored value along with metadata such as timestamp and optional expiry time.
+ */
+public record Entry(
+        RespType value,
+        long timestamp,
+        long expiryTime
+        ) {
+
+    /**
+     * Constructor for creating an Entry without expiry time.
+     *
+     * @param value
+     */
+    public Entry(RespType value) {
+        this(value, System.currentTimeMillis(), 0);
+    }
+
+    /**
+     * Constructor for creating an Entry with a specified expiry time.
+     *
+     * @param value
+     * @param expiryTime
+     */
+    public Entry(RespType value, long expiryTime) {
+        this(value, System.currentTimeMillis(), expiryTime);
+    }
+
+    /**
+     * Checks if the entry has expired based on the current time and its expiry
+     * time.
+     *
+     * @return
+     */
+    public boolean isExpired() {
+        if (expiryTime <= 0) {
+            return false; // No expiry set
+        }
+        return System.currentTimeMillis() > (timestamp + expiryTime);
+    }
+
+}

--- a/src/main/java/com/spring/memodb/store/Store.java
+++ b/src/main/java/com/spring/memodb/store/Store.java
@@ -1,0 +1,124 @@
+package com.spring.memodb.store;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Singleton class representing an in-memory key-value store. It provides
+ * thread-safe methods to get, put, and remove entries from the store.
+ */
+@Slf4j
+public class Store {
+
+    private volatile static Store instance; // singleton instance
+    private final ConcurrentHashMap<String, Entry> store = new ConcurrentHashMap<>(); // thread-safe map
+
+    /**
+     * Private constructor to prevent instantiation from outside the class.
+     */
+    private Store() {
+    }
+
+    /**
+     * Gets the singleton instance of the Store. If the instance does not exist,
+     * it is created in a thread-safe manner.
+     *
+     * @return
+     */
+    public static Store getInstance() {
+        if (instance != null) {
+            return instance;
+        }
+
+        synchronized (Store.class) {
+            if (instance == null) {
+                instance = new Store();
+            }
+            return instance;
+        }
+    }
+
+    /**
+     * Gets the Entry associated with the given key.
+     *
+     * @param key
+     * @return the Entry if found, null otherwise
+     */
+    public Entry get(String key) {
+        log.debug("Store: Getting entry for key: {}", key);
+
+        Entry entry = store.get(key);
+
+        if (entry == null) {
+            log.debug("Store: No entry found for key: {}", key);
+            return null;
+        }
+
+        if (entry.isExpired()) {
+            log.debug("Store: Entry for key: {} has expired. Removing it from store.", key);
+            store.remove(key);
+            return null;
+        }
+
+        log.debug("Store: Entry found for key: {}", key);
+        return entry;
+    }
+
+    /**
+     * Puts the given Entry into the store with the specified key.
+     *
+     * @param key
+     * @param entry
+     */
+    public void put(String key, Entry entry) {
+        log.debug("Store: Putting entry for key: {}", key);
+
+        store.put(key, entry);
+    }
+
+    /**
+     * Removes the Entry associated with the given key from the store.
+     *
+     * @param key
+     */
+    public void remove(String key) {
+        log.debug("Store: Removing entry for key: {}", key);
+
+        store.remove(key);
+    }
+
+    /**
+     * Checks if the store contains the given key.
+     *
+     * @param key
+     * @return true if the key exists, false otherwise
+     */
+    public boolean containsKey(String key) {
+
+        return store.containsKey(key);
+    }
+
+    /**
+     * Gets the current size of the store.
+     *
+     * @return the number of entries in the store
+     */
+    public int size() {
+        return store.size();
+    }
+
+    /**
+     * Cleans up expired entries from the store. This method iterates through
+     * the entries and removes those that have expired.
+     */
+    public void cleanupExpiredEntries() {
+        store.entrySet().removeIf((entry) -> {
+            if (entry.getValue().isExpired()) {
+                log.debug("Removing expired entry for key: {}", entry.getKey());
+                return true;
+            }
+            return false;
+        });
+    }
+}

--- a/src/main/java/com/spring/memodb/store/StoreCleanupService.java
+++ b/src/main/java/com/spring/memodb/store/StoreCleanupService.java
@@ -1,0 +1,24 @@
+package com.spring.memodb.store;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Service class responsible for scheduling periodic cleanup of expired entries
+ * in the Store.
+ */
+@Service
+@Slf4j
+public class StoreCleanupService {
+
+    @Scheduled(fixedRate = 60000) // every 1 minute (milliseconds)
+    public void scheduledCleanup() {
+        log.debug("StoreCleanupService: Running scheduled cleanup of expired entries.");
+
+        Store.getInstance().cleanupExpiredEntries();
+
+        log.debug("StoreCleanupService: Expired entries cleaned up. Current store size: {}", Store.getInstance().size());
+    }
+}


### PR DESCRIPTION
Implemented the core in-memory store using a thread-safe ConcurrentHashMap.

Key Features and Changes

- `Entry.java`:  Immutable entry representing the value stored in the HashMap against a key. Each entry has a `value` of `RespType`, a `timestamp` representing it's creation time, and an `expiryTime` (`<= 0` represents no expiry set).
- `Store.java`: Implements a thread-safe, singleton, store with ConcurrentHashMap. Exposes common functions like an expiry-aware `get`, `put`, `set`, `remove` operations and a `cleanupExpiredEntries` function to clean-up the expired keys.
- `StoreCleanupService.java`: A scheduled job which executes every 60 seconds and cleans-up the expired keys.
